### PR TITLE
fix: Load values as strings to serialize correctly

### DIFF
--- a/lib/enum_type.ex
+++ b/lib/enum_type.ex
@@ -121,7 +121,7 @@ defmodule EnumType do
         def cast(unquote(option)), do: {:ok, unquote(option)}
         def cast(unquote(value)), do: {:ok, unquote(option)}
 
-        def load(unquote(value)), do: {:ok, unquote(option)}
+        def load(unquote(value)), do: {:ok, unquote(option).value}
 
         # Allow both querying by Module and setting a value to the Module when updating or inserting.
         def dump(unquote(option)), do: {:ok, unquote(option).value}

--- a/lib/enum_type.ex
+++ b/lib/enum_type.ex
@@ -121,10 +121,12 @@ defmodule EnumType do
         def cast(unquote(option)), do: {:ok, unquote(option)}
         def cast(unquote(value)), do: {:ok, unquote(option)}
 
-        def load(unquote(value)), do: {:ok, unquote(option).value}
+        def load(unquote(value)), do: {:ok, unquote(value)}
 
         # Allow both querying by Module and setting a value to the Module when updating or inserting.
-        def dump(unquote(option)), do: {:ok, unquote(option).value}
+        def dump(unquote(option)), do: {:ok, unquote(value)}
+        def dump(unquote(value)), do: {:ok, unquote(value)}
+
       end
     end
   end


### PR DESCRIPTION
Previously, when an enum would be loaded, it would be loaded as the. module name. When the schema was serialized, the module name wasn't changed to the string, causing the returned JSON to be something like:

```
%{
  status: "Elixir.MyApp.Status.Published"
}
```